### PR TITLE
Add text highlight feature

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2275,6 +2275,12 @@ body.dark-mode .resources-category {
   margin: 0 auto;
 }
 
+/* Highlighted text */
+.text-highlight {
+  padding: 2px;
+  border-radius: 2px;
+}
+
 /* Utility Classes */
 .visually-hidden {
   position: absolute;

--- a/index.html
+++ b/index.html
@@ -264,6 +264,10 @@
                             <button class="btn btn-outline" id="toggle-notes-btn">
                                 <i class="far fa-sticky-note"></i> Notes
                             </button>
+                            <button class="btn btn-outline" id="highlight-btn">
+                                <i class="fas fa-highlighter"></i> Highlight
+                            </button>
+                            <input type="color" id="highlight-color-picker" style="display:none">
                         </div>
                     </div>
                     

--- a/js/storage.js
+++ b/js/storage.js
@@ -17,6 +17,7 @@ const Storage = {
     // User content
     bookmarks: [],
     notes: {},
+    highlights: {},
     
     // Activity history
     activities: [],
@@ -355,6 +356,45 @@ const Storage = {
       this.saveUserData(userData);
     }
     
+    return userData;
+  },
+
+  /**
+   * Save highlighted HTML for a topic
+   * @param {string} topicId - Topic ID
+   * @param {string} html - Highlighted HTML content
+   * @param {Object} userData - User data object
+   * @returns {Object} Updated user data
+   */
+  saveHighlights(topicId, html, userData) {
+    userData.highlights[topicId] = html;
+    userData.lastUpdated = Date.now();
+    this.saveUserData(userData);
+    return userData;
+  },
+
+  /**
+   * Get saved highlights for a topic
+   * @param {string} topicId - Topic ID
+   * @param {Object} userData - User data object
+   * @returns {string|null} HTML string or null
+   */
+  getHighlights(topicId, userData) {
+    return userData.highlights[topicId] || null;
+  },
+
+  /**
+   * Clear highlights for a topic
+   * @param {string} topicId - Topic ID
+   * @param {Object} userData - User data object
+   * @returns {Object} Updated user data
+   */
+  clearHighlights(topicId, userData) {
+    if (userData.highlights[topicId]) {
+      delete userData.highlights[topicId];
+      userData.lastUpdated = Date.now();
+      this.saveUserData(userData);
+    }
     return userData;
   },
   


### PR DESCRIPTION
## Summary
- allow users to highlight selected text in topics
- persist highlighted HTML per topic in storage
- add highlight button with color picker
- basic styles for `.text-highlight`

## Testing
- `node -c js/ui-manager.js && node -c js/storage.js`

------
https://chatgpt.com/codex/tasks/task_e_683f5f685e7c83309d9dd999adac52f7